### PR TITLE
Update requirements.txt

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,6 +1,6 @@
 argh
 beautifulsoup4==4.9.3
-celery==5.1.2
+celery==5.2.7
 degoogle==1.0.1
 discord-webhook==0.14.0
 Django==3.2.4


### PR DESCRIPTION
Update celery version to 5.2.7 
with the proposed changes to the Dockerfile, rengine now gets up and running by following the docs again: confirmed on Ubuntu 22.04.1 LTS (GNU/Linux 5.15.0-66-generic x86_64)  (digital ocean droplet)