### PR TITLE
Update Dockerfile

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -42,9 +42,9 @@ RUN apt update -y && apt install -y  --no-install-recommends \
 
 
 # Download and install go 1.18
-RUN wget https://golang.org/dl/go1.18.2.linux-amd64.tar.gz
-RUN tar -xvf go1.18.2.linux-amd64.tar.gz
-RUN rm go1.18.2.linux-amd64.tar.gz
+RUN wget https://golang.org/dl/go1.20.linux-amd64.tar.gz
+RUN tar -xvf go1.20.linux-amd64.tar.gz
+RUN rm go1.20.linux-amd64.tar.gz
 RUN mv go /usr/local
 
 # Download geckodriver


### PR DESCRIPTION
Update go minimum version, so the install script works (from 1.18.2 to 1.20)  also udpating celery version in requirements.txt  and that's all that's needed for sudo ./install.sh to function again (if the docs are followed for debian/ubuntu)